### PR TITLE
Fixing a minor error 

### DIFF
--- a/src/clojure/uncomplicate/bayadera/internal/device/amd_gcn.clj
+++ b/src/clojure/uncomplicate/bayadera/internal/device/amd_gcn.clj
@@ -358,7 +358,7 @@
   (sample! [this n-or-res]
    (let [available (* DIM (entry-width claccessor) walker-count)]
       (let-release [res (if (integer? n-or-res)
-                          (ge neanderthal-factory DIM walker-count {:raw true})
+                          (ge neanderthal-factory DIM n-or-res {:raw true})
                           n-or-res)]
         (set-temperature! this 1.0)
         (loop [ofst 0 requested (* DIM (entry-width claccessor) (ncols res))]

--- a/src/clojure/uncomplicate/bayadera/internal/device/nvidia_gtx.clj
+++ b/src/clojure/uncomplicate/bayadera/internal/device/nvidia_gtx.clj
@@ -371,7 +371,7 @@
      ctx
      (let [available (* DIM (entry-width cuaccessor) walker-count)]
        (let-release [res (if (integer? n-or-res)
-                           (ge neanderthal-factory DIM walker-count {:raw true})
+                           (ge neanderthal-factory DIM n-or-res {:raw true})
                            n-or-res)]
          (set-temperature! this 1.0)
          (loop [ofst 0 requested (* DIM (entry-width cuaccessor) (ncols res))]


### PR DESCRIPTION
This error prevents custom size sampling on nvidia cuda and amd. The variable passed is currently ignored, which shouldn't happen.
By correcting this - custom size sampling works correctly, even on cuda.